### PR TITLE
Fix docgen workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           # We have to build the parser every single time to keep up with parser changes
           cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
-          git checkout 86f74dfb69c570f0749b241f8f5489f8f50adbea
           make dist
           cd -
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           # We have to build the parser every single time to keep up with parser changes
           cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
+          git checkout 5429f4ed6865c43fbfb07001ad9bfe33ec6e96db
           make dist
           cd -
 


### PR DESCRIPTION
Sorry about the surge in pull requests, I recently started making my own plugin and found some issues with your template (it's amazing by the way, thanks for it). In hindsight I should have bundled everything together but mistakenly felt like each new PR would be the last.

This issue that I noticed is actually also present in some popular repositories, like [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) ([telescope's error](https://github.com/nvim-telescope/telescope.nvim/actions/runs/7964023845/job/21740738767)). When I used your `docs.yml` workflow (which I found to be derived from `telescope.nvim`), it always seemed to pass but never seemed to actually generate the docs. The error was always consistent:
```
E5113: Error while calling lua chunk: ...te/pack/vendor/start/tree-sitter-lua/lua/docgen/init.lua:24: attempt to call field 'require_language' (a nil value)
```
Tracking it down, it led to [tree-sitter-lua](https://github.com/tjdevries/tree-sitter-lua/blob/master/lua/docgen/init.lua)...but in this file `line 24` was empty...

Looking back at the `docs.yml` file, I found it to be checking out the repo at a certain commit where the file was in [this state](https://github.com/tjdevries/tree-sitter-lua/blob/86f74dfb69c570f0749b241f8f5489f8f50adbea/lua/docgen/init.lua) (this line has been removed for this PR). I believe this was some outdated method and by using the latest `docgen` every  time we generate docs there shouldn't be any more issues.